### PR TITLE
Add Kisumu National Polytechnic

### DIFF
--- a/lib/domains/ke/ac/kisumupoly.txt
+++ b/lib/domains/ke/ac/kisumupoly.txt
@@ -1,0 +1,1 @@
+The Kisumu National Polytechnic


### PR DESCRIPTION
Kindly add Kisumu National Polytechnic to JetBrains. Kisumu Polytechnic is a well-known institution of higher learning located in Kisumu, Kenya. It offers a wide range of technical and vocational courses to empower students with practical skills for the job market. 

Domain is kisumupoly.ac.ke